### PR TITLE
Add landing page and customize superadmin interface

### DIFF
--- a/glossario/admin.py
+++ b/glossario/admin.py
@@ -1,10 +1,26 @@
+from django import forms
 from django.contrib import admin
 
 from .models import Termo
 
 
+class TermoAdminForm(forms.ModelForm):
+    fotos = forms.JSONField(required=False, widget=forms.Textarea)
+    videos = forms.JSONField(required=False, widget=forms.Textarea)
+
+    class Meta:
+        model = Termo
+        fields = "__all__"
+
+
 @admin.register(Termo)
 class TermoAdmin(admin.ModelAdmin):
+    form = TermoAdminForm
     prepopulated_fields = {"slug": ("titulo",)}
     search_fields = ["titulo", "decod_en", "decod_pt"]
     list_display = ("titulo", "decod_en", "decod_pt")
+
+
+admin.site.site_header = "Aerodicionário Superadmin"
+admin.site.site_title = "Aerodicionário Superadmin"
+admin.site.index_title = "Gerenciamento do Aerodicionário"

--- a/glossario/serializers.py
+++ b/glossario/serializers.py
@@ -16,3 +16,7 @@ class TermoSerializer(serializers.ModelSerializer):
             "videos",
             "links",
         ]
+        extra_kwargs = {
+            "fotos": {"required": False},
+            "videos": {"required": False},
+        }

--- a/glossario/urls.py
+++ b/glossario/urls.py
@@ -5,8 +5,9 @@ from . import views
 app_name = "glossario"
 
 urlpatterns = [
-    path("termos/", views.lista_termos, name="lista_termos"),
-    path("termos/<slug:slug>/", views.detalhes_termo, name="detalhes_termo"),
+    path("", views.home, name="home"),
+    path("dicionario/", views.lista_termos, name="lista_termos"),
+    path("dicionario/<slug:slug>/", views.detalhes_termo, name="detalhes_termo"),
     path("api/termos/", views.TermoListAPI.as_view(), name="api_lista_termos"),
     path("api/termos/<slug:slug>/", views.TermoDetailAPI.as_view(), name="api_detalhes_termo"),
 ]

--- a/glossario/views.py
+++ b/glossario/views.py
@@ -6,6 +6,11 @@ from .models import Termo
 from .serializers import TermoSerializer
 
 
+def home(request):
+    """Landing page for the project."""
+    return render(request, "home.html")
+
+
 def lista_termos(request):
     busca = request.GET.get("q", "")
     termos = Termo.objects.all()

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,20 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
       <div class="container">
         <a class="navbar-brand fw-bold" href="/">Aerodicionário</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+          aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item">
+              <a class="nav-link" href="{% url 'glossario:lista_termos' %}">Dicionário</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/admin/">Admin</a>
+            </li>
+          </ul>
+        </div>
       </div>
     </nav>
   </header>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Aerodicionário{% endblock %}
+{% block content %}
+<div class="p-5 mb-4 bg-light rounded-3">
+  <div class="container-fluid py-5">
+    <h1 class="display-5 fw-bold">Bem-vindo ao Aerodicionário</h1>
+    <p class="col-md-8 fs-4">Explore termos e siglas da aviação em nosso dicionário interativo.</p>
+    <a class="btn btn-primary btn-lg" href="{% url 'glossario:lista_termos' %}">Acessar Dicionário</a>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Build Bootstrap landing page with navigation to the dictionary
- Expose dictionary pages under `/dicionario` and link in navigation
- Customize Django admin and make photo/video fields optional

## Testing
- `npm test`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c66604b483229a7bf29f40b52230