### PR TITLE
Improve landing page design and SEO

### DIFF
--- a/glossario/static/img/airplane-illustration.svg
+++ b/glossario/static/img/airplane-illustration.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80">
+  <rect width="120" height="80" fill="#e9ecef"/>
+  <text x="60" y="50" font-size="40" text-anchor="middle" fill="#6c757d">✈</text>
+</svg>

--- a/glossario/static/img/logo.svg
+++ b/glossario/static/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#0d6efd"/>
+  <text x="50" y="55" font-size="50" text-anchor="middle" fill="#fff">✈</text>
+</svg>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,28 +1,53 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="pt-br">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Aerodicionário{% endblock %}</title>
+  <meta name="description" content="{% block meta_description %}Glossário de termos e siglas da aviação para estudantes e profissionais do setor aéreo.{% endblock %}">
+  <meta name="keywords" content="aviação, dicionário, glossário, termos aeronáuticos, siglas aéreas">
+  <meta name="robots" content="index, follow">
+  <meta property="og:title" content="{% block og_title %}{% block title %}Aerodicionário{% endblock %}{% endblock %}">
+  <meta property="og:description" content="{% block og_description %}Glossário de termos e siglas da aviação para estudantes e profissionais do setor aéreo.{% endblock %}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ request.build_absolute_uri|default:'' }}">
+  <link rel="canonical" href="{{ request.build_absolute_uri|default:'' }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Aerodicionário",
+    "url": "https://aerodicionario.example/",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://aerodicionario.example/glossario?q={search_term_string}",
+      "query-input": "required name=search_term_string"
+    }
+  }
+  </script>
+  {% block extra_head %}{% endblock %}
 </head>
 <body class="d-flex flex-column min-vh-100">
   <header>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary" aria-label="Menu principal">
       <div class="container">
-        <a class="navbar-brand fw-bold" href="/">Aerodicionário</a>
+          <a class="navbar-brand d-flex align-items-center" href="/">
+          <img src="{% static 'img/logo.svg' %}" alt="Logotipo Aerodicionário" width="40" height="40" class="me-2">
+          <span class="fw-bold">Aerodicionário</span>
+        </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
-          aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          aria-controls="navbarNav" aria-expanded="false" aria-label="Abrir menu">
           <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
           <ul class="navbar-nav ms-auto">
-            <li class="nav-item">
-              <a class="nav-link" href="{% url 'glossario:lista_termos' %}">Dicionário</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/admin/">Admin</a>
-            </li>
+            <li class="nav-item"><a class="nav-link" href="/">Início</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'glossario:lista_termos' %}">Dicionário</a></li>
+            <li class="nav-item"><a class="nav-link" href="/#sobre">Sobre</a></li>
+            <li class="nav-item"><a class="nav-link" href="/#contato">Contato</a></li>
+            <li class="nav-item"><a class="nav-link" href="/admin/">Admin</a></li>
           </ul>
         </div>
       </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,11 +1,61 @@
 {% extends 'base.html' %}
-{% block title %}Aerodicionário{% endblock %}
+{% load static %}
+{% block title %}Aerodicionário - Glossário de Termos de Aviação{% endblock %}
+{% block meta_description %}Dicionário da aviação com definições de siglas e termos aeronáuticos em português. Descubra rapidamente significados e amplie seu vocabulário aéreo.{% endblock %}
 {% block content %}
-<div class="p-5 mb-4 bg-light rounded-3">
-  <div class="container-fluid py-5">
-    <h1 class="display-5 fw-bold">Bem-vindo ao Aerodicionário</h1>
-    <p class="col-md-8 fs-4">Explore termos e siglas da aviação em nosso dicionário interativo.</p>
-    <a class="btn btn-primary btn-lg" href="{% url 'glossario:lista_termos' %}">Acessar Dicionário</a>
+<section class="py-5 text-center bg-light">
+  <div class="container">
+    <h1 class="display-4 fw-bold">Seu guia de termos e siglas da aviação</h1>
+    <p class="lead">Da cabine de comando ao solo, descubra a linguagem que move o céu.</p>
+    <a class="btn btn-primary btn-lg" href="{% url 'glossario:lista_termos' %}">Consultar Dicionário</a>
   </div>
-</div>
+</section>
+
+<section id="sobre" class="py-5">
+  <div class="container">
+    <div class="row align-items-center">
+      <div class="col-md-6">
+        <h2>Sobre o Aerodicionário</h2>
+        <p>O Aerodicionário reúne definições claras e objetivas para estudantes, entusiastas e profissionais do setor aéreo.</p>
+        <p>Nosso objetivo é facilitar o aprendizado com conteúdo confiável e atualizado continuamente.</p>
+      </div>
+      <div class="col-md-6">
+        <img src="{% static 'img/airplane-illustration.svg' %}" alt="Ilustração de avião" class="img-fluid">
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="recursos" class="py-5 bg-light">
+  <div class="container">
+    <h2 class="text-center mb-4">Por que usar o Aerodicionário?</h2>
+    <div class="row g-4">
+      <div class="col-md-4">
+        <div class="h-100 p-4 border rounded">
+          <h3 class="h5">Conteúdo atualizado</h3>
+          <p>Mantemos nosso banco de dados em constante expansão com os termos mais recentes do setor.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="h-100 p-4 border rounded">
+          <h3 class="h5">Busca rápida</h3>
+          <p>Encontre qualquer expressão em segundos usando a pesquisa do dicionário.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="h-100 p-4 border rounded">
+          <h3 class="h5">Acesso gratuito</h3>
+          <p>Consulte o conteúdo de onde estiver sem custos.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="contato" class="py-5">
+  <div class="container text-center">
+    <h2>Entre em contato</h2>
+    <p>Tem alguma sugestão ou correção? Envie um e-mail para <a href="mailto:contato@aerodicionario.example">contato@aerodicionario.example</a>.</p>
+  </div>
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add SEO metadata, Open Graph tags, and structured data to base template
- Redesign navigation with logo placeholder and expanded menu
- Create richer landing page with hero copy, about, features, and contact sections
- Include placeholder SVG assets for logo and illustration

## Testing
- `npm test`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c1de490dfc8322bf77f24fab790851